### PR TITLE
Fix installer base URL and quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ TaskArena SaaS installs a background worker service that orchestrates Claude CLI
 ## Quick start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/DevangML/TaskArena/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/DevangML/TaskArena/main/install.sh | bash
 ```
 
 After installation the `ta` command is ready:

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_URL="https://raw.githubusercontent.com/<YOUR_GH_USER>/taskarena-saas/main"
+# Allow overriding the base download URL (useful for forks or mirrors)
+DEFAULT_BASE_URL="https://raw.githubusercontent.com/DevangML/TaskArena/main"
+BASE_URL="${TASKARENA_BASE_URL:-${DEFAULT_BASE_URL}}"
 STATE_DIR="${HOME}/.taskarena"
 BIN_DIR="${HOME}/.local/bin"
 QUEUE_DIRS=("queue/inbox" "queue/running" "queue/done" "queue/failed")


### PR DESCRIPTION
## Summary
- point the installer at the TaskArena repository by default while allowing overrides via TASKARENA_BASE_URL
- correct the README quick start curl command to include the main branch path

## Testing
- bash -n install.sh

------
https://chatgpt.com/codex/tasks/task_e_68cfb06203188332a78517363d7d9818